### PR TITLE
Enable the plugin to assume a role

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ This are the properties you can configure and what are the default values:
     * **default value**: `nil`
 * `profile`: The AWS profile name for authentication. This ensures that the `~/.aws/credentials` AWS auth provider is used. By default this is empty and the default chain will be used.
     * **required**: false
-    * **default value**: `""`    
+    * **default value**: `""`
+* `role_arn`: The AWS role to assume. This can be used, for example, to access a Kinesis stream in a different AWS
+account. This role will be assumed after the default credentials or profile credentials are created. By default
+this is empty and a role will not be assumed.
+    * **required**: false
+    * **default value**: `""`
 * `initial_position_in_stream`: The value for initialPositionInStream. Accepts "TRIM_HORIZON" or "LATEST".
     * **required**: false
     * **default value**: `"TRIM_HORIZON"`

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ task wrapper(type: Wrapper) {
 dependencies {
   compile 'com.amazonaws:aws-java-sdk-kms:1.11.14'
   compile 'com.amazonaws:amazon-kinesis-client:1.7.0'
+  compile 'com.amazonaws:aws-java-sdk-sts:1.11.14'
   compile 'com.amazonaws:aws-java-sdk-core:1.11.16'
   compile 'commons-codec:commons-codec:1.9'
   compile 'com.fasterxml.jackson.core:jackson-databind:2.6.6'

--- a/lib/logstash-input-kinesis_jars.rb
+++ b/lib/logstash-input-kinesis_jars.rb
@@ -4,6 +4,7 @@ require 'jar_dependencies'
 require_jar('com.amazonaws', 'aws-java-sdk-kms', '1.11.14')
 require_jar('com.amazonaws', 'amazon-kinesis-client', '1.7.0')
 require_jar('com.amazonaws', 'aws-java-sdk-core', '1.11.16')
+require_jar('com.amazonaws', 'aws-java-sdk-sts', '1.11.14')
 require_jar('commons-codec', 'commons-codec', '1.9')
 require_jar('com.fasterxml.jackson.core', 'jackson-databind', '2.6.6')
 require_jar('com.google.guava', 'guava', '18.0')

--- a/lib/logstash/inputs/kinesis.rb
+++ b/lib/logstash/inputs/kinesis.rb
@@ -53,6 +53,9 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
   # Select AWS profile for input
   config :profile, :validate => :string
 
+  # Assume a different role using STS, for example if the stream is in a different AWS account
+  config :role_arn, :validate => :string
+
   # Select initial_position_in_stream. Accepts TRIM_HORIZON or LATEST
   config :initial_position_in_stream, :validate => ["TRIM_HORIZON", "LATEST"], :default => "TRIM_HORIZON"
 
@@ -78,6 +81,15 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
     else
       creds = com.amazonaws.auth::DefaultAWSCredentialsProviderChain.new
     end
+
+    # If a role ARN is set then assume the role as a new layer over the credentials already created
+    unless @role_arn.nil?
+      session_id = "worker" + worker_id
+      kinesis_creds = com.amazonaws.auth::STSAssumeRoleSessionCredentialsProvider.new(creds, @role_arn, session_id)
+    else
+      kinesis_creds = creds
+    end
+
     initial_position_in_stream = if @initial_position_in_stream == "TRIM_HORIZON"
       KCL::InitialPositionInStream::TRIM_HORIZON
     else
@@ -87,7 +99,9 @@ class LogStash::Inputs::Kinesis < LogStash::Inputs::Base
     @kcl_config = KCL::KinesisClientLibConfiguration.new(
       @application_name,
       @kinesis_stream_name,
-      creds,
+      kinesis_creds, # credential provider for accessing the kinesis stream
+      creds, # credential provider for creating / accessing the dynamo table
+      creds, # credential provider for cloudwatch metrics
       worker_id).
         withInitialPositionInStream(initial_position_in_stream).
         withRegionName(@region)

--- a/spec/inputs/kinesis_spec.rb
+++ b/spec/inputs/kinesis_spec.rb
@@ -26,6 +26,17 @@ RSpec.describe "inputs/kinesis" do
     "profile" => "my-aws-profile"
   }}
 
+  # Config hash to test assume role provider if role_arn is specified
+  let(:config_with_role_arn) {{
+    "application_name" => "my-processor",
+    "kinesis_stream_name" => "run-specs",
+    "codec" => codec,
+    "metrics" => metrics,
+    "checkpoint_interval_seconds" => 120,
+    "region" => "ap-southeast-1",
+    "role_arn" => "arn:aws:iam::???????????:role/my-role"
+  }}
+
   # other config with LATEST as initial_position_in_stream
   let(:config_with_latest) {{
     "application_name" => "my-processor",
@@ -64,6 +75,15 @@ RSpec.describe "inputs/kinesis" do
   it "uses ProfileCredentialsProvider if profile is specified" do
     kinesis_with_profile.register
     expect(kinesis_with_profile.kcl_config.get_kinesis_credentials_provider.getClass.to_s).to eq("com.amazonaws.auth.profile.ProfileCredentialsProvider")
+  end
+
+  subject!(:kinesis_with_role_arn) { LogStash::Inputs::Kinesis.new(config_with_role_arn) }
+
+  it "uses STS for accessing the kinesis stream if role_arn is specified" do
+    kinesis_with_role_arn.register
+    expect(kinesis_with_role_arn.kcl_config.get_kinesis_credentials_provider.getClass.to_s).to eq("com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider")
+    expect(kinesis_with_role_arn.kcl_config.get_dynamo_db_credentials_provider.getClass.to_s).to eq("com.amazonaws.auth.DefaultAWSCredentialsProviderChain")
+    expect(kinesis_with_role_arn.kcl_config.get_cloud_watch_credentials_provider.getClass.to_s).to eq("com.amazonaws.auth.DefaultAWSCredentialsProviderChain")
   end
 
   subject!(:kinesis_with_latest) { LogStash::Inputs::Kinesis.new(config_with_latest) }


### PR DESCRIPTION
We have a requirement to get data from a Kinesis stream in a different AWS account.

This PR adds a new `role_arn` config option that takes an AWS role ARN that will be assumed. This role is assumed from either the default or profile credentials. The newly created credential provider is used only for accessing the kinesis stream. Both dynamo and cloudwatch access by the KCL continue to be done using the underlying credential provider and so these resources are in the home account rather than the account containing the stream.